### PR TITLE
Fix README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Go test tutorial repository.
 
 ```bash
 # this command has bug
-$ go run cmd/shp1
+$ go run ./cmd/shp1
 # try debugging
 
 # for not VSCode user
@@ -17,6 +17,6 @@ $ go install github.com/cweill/gotests/...
 $ gotests -all -w credit_service.go 
 
 # this command also has bug
-$ go run cmd/shp2
+$ go run ./cmd/shp2
 # try debugging too
 ```


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->

```console
$ go run cmd/shp1
package cmd/shp1 is not in GOROOT (/usr/local/go/src/cmd/shp1)
```

README 記載のコマンドを実行しようとするとエラーが発生する環境がありそうだった。

## What
<!-- What features are added in this PR -->

```console
go run ./cmd/xxx
```

のように修正した。

## QA, Evidence
<!-- Things that support this PR is correct -->

```console
$ go run ./cmd/shp1
2023/08/10 09:17:53 Thank you for buying!!! Price: 1300000
```
